### PR TITLE
Pass a page description with the page capabilities filter

### DIFF
--- a/faq-manager.php
+++ b/faq-manager.php
@@ -71,9 +71,9 @@ class WP_FAQ_Manager
 
 	public function admin_pages() {
 		
-		add_submenu_page('edit.php?post_type=question', 'Sort FAQs', 'Sort FAQs', apply_filters( 'faq-caps-sort', 'manage_options' ), basename(__FILE__), array( &$this, 'sort_page' ));
-		add_submenu_page('edit.php?post_type=question', 'Settings', 'Settings', apply_filters( 'faq-caps-settings', 'manage_options' ), 'faq-options', array( &$this, 'settings_page' ));
-		add_submenu_page('edit.php?post_type=question', 'Instructions', 'Instructions', apply_filters( 'faq-caps-instructions', 'manage_options' ), 'faq-instructions', array( &$this, 'instructions_page' ));
+		add_submenu_page('edit.php?post_type=question', 'Sort FAQs', 'Sort FAQs', apply_filters( 'faq-caps', 'manage_options', 'sort' ), basename(__FILE__), array( &$this, 'sort_page' ));
+		add_submenu_page('edit.php?post_type=question', 'Settings', 'Settings', apply_filters( 'faq-caps', 'manage_options', 'settings' ), 'faq-options', array( &$this, 'settings_page' ));
+		add_submenu_page('edit.php?post_type=question', 'Instructions', 'Instructions', apply_filters( 'faq-caps', 'manage_options', 'instructions' ), 'faq-instructions', array( &$this, 'instructions_page' ));
 	}
 
 	/**


### PR DESCRIPTION
This allows granular control for each capability (e.g., let anybody with 'read' see instructions, let anybody with 'publish_posts' see sort, and use manage_options for the settings page) by doing something like this:

``` php
add_filter( 'faq-caps', function( $cap, $page ){
  switch($page){
    case 'sort':
      return 'publish_posts';
      break;
    default:
      return $cap;
      break;
}, 10, 2 );
```
