### PR TITLE
Improve compatibility of Random FAQ widget

### DIFF
--- a/faq-manager.php
+++ b/faq-manager.php
@@ -992,7 +992,7 @@ class random_FAQ_Widget extends WP_Widget {
 			$faqs = get_posts( $args );
 			
 			foreach( $faqs as $faq ) :
-				$text = get_the_content( $faq->ID );
+				$text = wpautop( $faq->post_content );
  			
 				echo '<h4 class="faq_widget_title">' . $faq->post_title . '</h4>';
 				echo wp_trim_words( $text, 15, null );


### PR DESCRIPTION
In the site I was working on, the Random FAQ widget was displaying the title and link of the current page rather than those of an FAQ. This was because the widget was using the global $post variable. This commit diverts the get_post data into a local-scope variable instead to prevent this from happening.
