### PR TITLE
Don't use create_function()

### DIFF
--- a/faq-manager.php
+++ b/faq-manager.php
@@ -55,6 +55,7 @@ class WP_FAQ_Manager
 		add_action					( 'wp_head', 						array( $this, 'seo_head'		), 5		);
 		add_action					( 'wp_head', 						array( $this, 'print_css'		), 999		);
 		add_action					( 'admin_enqueue_scripts', 			array( $this, 'admin_scripts'	), 10		);
+		add_action					( 'widgets_init',					array( $this, 'register_widgets')			);
 		add_filter					( 'enter_title_here',				array( $this, 'title_text'		) 			);
 		add_filter					( 'pre_get_posts',					array( $this, 'rss_include'		) 			);
 		add_filter					( 'faq-caps',						array( $this, 'menu_filter'		), 10, 2	);
@@ -65,6 +66,25 @@ class WP_FAQ_Manager
 		add_shortcode				( 'faqcombo',						array( $this, 'shortcode_combo'	) 			);
 		add_shortcode				( 'faqtaxlist',						array( $this, 'shortcode_taxls'	) 			);
 
+	}
+
+	public function register_widgets() {
+		if( class_exists( 'search_FAQ_Widget' ) ) {
+			register_widget('search_FAQ_Widget');
+		}
+
+		if( class_exists( 'random_FAQ_Widget' ) ) {
+			register_widget('random_FAQ_Widget');
+		}
+		if( class_exists( 'recent_FAQ_Widget' ) ) {
+			register_widget('recent_FAQ_Widget');
+		}
+		if( class_exists( 'topics_FAQ_Widget' ) ) {
+			register_widget('topics_FAQ_Widget');
+		}
+		if( class_exists( 'cloud_FAQ_Widget' ) ) {
+			register_widget('cloud_FAQ_Widget' );
+		}
 	}
 
 	/**

--- a/faq-widgets.php
+++ b/faq-widgets.php
@@ -394,16 +394,3 @@ class cloud_FAQ_Widget extends WP_Widget {
 
 
 } // class 
-
-	/**
-	 * Register all widgets
-	 *
-	 * @return WP_FAQ_Manager
-	 */
-
-
-add_action( 'widgets_init', create_function( '', "register_widget('search_FAQ_Widget');" ) );
-add_action( 'widgets_init', create_function( '', "register_widget('random_FAQ_Widget');" ) );
-add_action( 'widgets_init', create_function( '', "register_widget('recent_FAQ_Widget');" ) );
-add_action( 'widgets_init', create_function( '', "register_widget('topics_FAQ_Widget');" ) );
-add_action( 'widgets_init', create_function( '', "register_widget('cloud_FAQ_Widget');" ) );


### PR DESCRIPTION
I ran into problems debugging with Xdebug, it turns out it doesn't like adding filters with create_function().  Add to that the fact that create_function() is a wrapper for eval(), I thought it would be a good idea to get rid of it.
